### PR TITLE
feat: add URL type, rename Str64From, add interface guards, improve g…

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -1,6 +1,7 @@
 package typx
 
 import (
+	"encoding"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -8,20 +9,22 @@ import (
 	"time"
 )
 
-// Duration is a struct that represents a duration of time, including both a time.Duration and additional fields for days and months.
+// [Duration] is a struct that represents a duration of time, including both a [time.Duration] and additional fields for days and months.
 // This allows for more flexible time calculations that can account for varying lengths of days and months.
 type Duration struct {
-	Time  time.Duration // The time.Duration field represents the time part of duration in terms of hours, minutes, seconds, etc.
+	Time  time.Duration // The [time.Duration] field represents the time part of duration in terms of hours, minutes, seconds, etc.
 	Day   int64         // The Day field represents the number of days in the duration. This is useful for calculations that need to account for varying lengths of days (e.g., due to daylight saving time changes).
 	Month int64         // The Month field represents the number of months in the duration. This is useful for calculations that need to account for varying lengths of months (e.g., due to the number of days in each month).
 }
 
-// String returns a string representation of the Duration, combining the time, day, and month components into a human-readable format.
+var _ fmt.Stringer = Duration{}
+
+// String returns a string representation of the [Duration], combining the time, day, and month components into a human-readable format.
 func (d Duration) String() string {
 	return fmt.Sprintf("%dM%dD%s", d.Month, d.Day, d.Time)
 }
 
-// Abs returns a new Duration with the absolute values of the time, day, and month components. This is useful for ensuring that all components of the duration are non-negative, regardless of their original signs.
+// Abs returns a new [Duration] with the absolute values of the time, day, and month components. This is useful for ensuring that all components of the duration are non-negative, regardless of their original signs.
 func (d Duration) Abs() Duration {
 	return Duration{
 		Time:  d.Time.Abs(),
@@ -30,7 +33,7 @@ func (d Duration) Abs() Duration {
 	}
 }
 
-// Add adds another Duration to the current Duration, combining their time, day, and month components.
+// Add adds another [Duration] to the current [Duration], combining their time, day, and month components.
 // The operation is similar to a vector addition, as they are independent unless a point in time is being calculated.
 func (d Duration) Add(other Duration) Duration {
 	return Duration{
@@ -40,7 +43,7 @@ func (d Duration) Add(other Duration) Duration {
 	}
 }
 
-// Sub subtracts another Duration from the current Duration, combining their time, day, and month components.
+// Sub subtracts another [Duration] from the current [Duration], combining their time, day, and month components.
 // The operation is similar to a vector subtraction, as they are independent unless a point in time is being calculated.
 func (d Duration) Sub(other Duration) Duration {
 	return Duration{
@@ -53,8 +56,9 @@ func (d Duration) Sub(other Duration) Duration {
 var iso8601DurationRe = regexp.MustCompile(
 	`^(-?)P(?:(-?\d+)Y)?(?:(-?\d+)M)?(?:(-?\d+)D)?(?:T(?:(-?\d+)H)?(?:(-?\d+)M)?(?:(-?\d+(?:\.\d+)?)S)?)?$`,
 )
+var _ encoding.TextMarshaler = Duration{}
 
-// MarshalText implements [encoding.TextMarshaler].
+// MarshalText implements the [encoding.TextMarshaler] interface.
 // Produces an ISO 8601 duration string (e.g. "P1Y2M3DT4H5M6.789S").
 // Month values >= 12 are expressed as years + remaining months.
 func (d Duration) MarshalText() ([]byte, error) {
@@ -111,7 +115,9 @@ func (d Duration) MarshalText() ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
-// UnmarshalText implements [encoding.TextUnmarshaler].
+var _ encoding.TextUnmarshaler = (*Duration)(nil)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
 // Accepts an ISO 8601 duration string (e.g. "P1Y2M3DT4H5M6.789S").
 // Years are converted to months (1Y = 12M).
 // A leading "-P" negates all components.

--- a/dyn.go
+++ b/dyn.go
@@ -10,23 +10,27 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// Dyn is a dynamic type that can hold any value type.
+// [Dyn] is a dynamic type that can hold any value type.
 // When using with SQL, the column should be a type that can hold JSON data (JSONB, JSON, TEXT, etc).
 type Dyn struct{ Val any }
 
-// MarshalJSON implements the json.Marshaler interface.
+var _ json.Marshaler = Dyn{}
+
+// MarshalJSON implements the [json.Marshaler] interface.
 func (d Dyn) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Val)
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface.
+var _ json.Unmarshaler = (*Dyn)(nil)
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
 func (d *Dyn) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &d.Val)
 }
 
-// Scan implements the sql.Scanner interface.
 var _ sql.Scanner = (*Dyn)(nil)
 
+// Scan implements the [sql.Scanner] interface.
 func (d *Dyn) Scan(src any) error {
 	if src == nil {
 		d.Val = nil
@@ -41,18 +45,24 @@ func (d *Dyn) Scan(src any) error {
 	return fmt.Errorf("typx.Dyn.Scan: %T is not a string or []byte", src)
 }
 
-// Value implements the driver.Valuer interface.
+var _ driver.Valuer = Dyn{}
+
+// Value implements the [driver.Valuer] interface.
 func (d Dyn) Value() (driver.Value, error) {
 	return json.Marshal(d.Val)
 }
 
-// MarshalBSONValue implements the bson.ValueMarshaler interface.
+var _ bson.ValueMarshaler = Dyn{}
+
+// MarshalBSONValue implements the [bson.ValueMarshaler] interface.
 func (d Dyn) MarshalBSONValue() (byte, []byte, error) {
 	t, data, err := bson.MarshalValue(d.Val)
 	return byte(t), data, err
 }
 
-// UnmarshalBSONValue implements the bson.ValueUnmarshaler interface.
+var _ bson.ValueUnmarshaler = (*Dyn)(nil)
+
+// UnmarshalBSONValue implements the [bson.ValueUnmarshaler] interface.
 func (d *Dyn) UnmarshalBSONValue(t byte, data []byte) error {
 	if err := bson.UnmarshalValue(bson.Type(t), data, &d.Val); err != nil {
 		return err
@@ -87,12 +97,16 @@ func convertBSONToNative(v any) any {
 	}
 }
 
-// MarshalBSON implements the bson.Marshaler interface for use as a standalone document.
+var _ bson.Marshaler = Dyn{}
+
+// MarshalBSON implements the [bson.Marshaler] interface for use as a standalone document.
 func (d Dyn) MarshalBSON() ([]byte, error) {
 	return bson.Marshal(d.Val)
 }
 
-// UnmarshalBSON implements the bson.Unmarshaler interface for use as a standalone document.
+var _ bson.Unmarshaler = (*Dyn)(nil)
+
+// UnmarshalBSON implements the [bson.Unmarshaler] interface for use as a standalone document.
 func (d *Dyn) UnmarshalBSON(data []byte) error {
 	if err := bson.Unmarshal(data, &d.Val); err != nil {
 		return err
@@ -104,7 +118,9 @@ func (d *Dyn) UnmarshalBSON(data []byte) error {
 // The following implementations are provided for convenience,
 // but they require that the underlying type implements the respective interfaces.
 
-// MarshalBinary implements the encoding.BinaryMarshaler interface.
+var _ encoding.BinaryMarshaler = Dyn{}
+
+// MarshalBinary implements the [encoding.BinaryMarshaler] interface.
 func (d Dyn) MarshalBinary() ([]byte, error) {
 	if marshaler, ok := d.Val.(encoding.BinaryMarshaler); ok {
 		return marshaler.MarshalBinary()
@@ -112,7 +128,9 @@ func (d Dyn) MarshalBinary() ([]byte, error) {
 	return nil, fmt.Errorf("typx.Dyn.MarshalBinary: %T does not implement encoding.BinaryMarshaler", d.Val)
 }
 
-// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+var _ encoding.BinaryUnmarshaler = (*Dyn)(nil)
+
+// UnmarshalBinary implements the [encoding.BinaryUnmarshaler] interface.
 func (d *Dyn) UnmarshalBinary(data []byte) error {
 	if unmarshaler, ok := d.Val.(encoding.BinaryUnmarshaler); ok {
 		return unmarshaler.UnmarshalBinary(data)
@@ -120,7 +138,9 @@ func (d *Dyn) UnmarshalBinary(data []byte) error {
 	return fmt.Errorf("typx.Dyn.UnmarshalBinary: %T does not implement encoding.BinaryUnmarshaler", d.Val)
 }
 
-// MarshalText implements the encoding.TextMarshaler interface.
+var _ encoding.TextMarshaler = Dyn{}
+
+// MarshalText implements the [encoding.TextMarshaler] interface.
 func (d Dyn) MarshalText() ([]byte, error) {
 	if marshaler, ok := d.Val.(encoding.TextMarshaler); ok {
 		return marshaler.MarshalText()
@@ -128,7 +148,9 @@ func (d Dyn) MarshalText() ([]byte, error) {
 	return nil, fmt.Errorf("typx.Dyn.MarshalText: %T does not implement encoding.TextMarshaler", d.Val)
 }
 
-// UnmarshalText implements the encoding.TextUnmarshaler interface.
+var _ encoding.TextUnmarshaler = (*Dyn)(nil)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
 func (d *Dyn) UnmarshalText(data []byte) error {
 	if unmarshaler, ok := d.Val.(encoding.TextUnmarshaler); ok {
 		return unmarshaler.UnmarshalText(data)

--- a/kv.go
+++ b/kv.go
@@ -1,6 +1,7 @@
 package typx
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -90,7 +91,7 @@ func (kvs *KVs[K, V]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var _ driver.Valuer = (*KVs[any, any])(nil)
+var _ sql.Scanner = (*KVs[any, any])(nil)
 
 // Scan implements the [sql.Scanner] interface.
 // The column should be a type that can hold JSON data (JSONB, JSON, TEXT, etc).
@@ -143,7 +144,7 @@ func (kvs *KVs[K, V]) UnmarshalBSONValue(t byte, data []byte) error {
 	return nil
 }
 
-var _ bson.ValueMarshaler = (*KVs[any, any])(nil)
+var _ bson.Marshaler = (*KVs[any, any])(nil)
 
 // MarshalBSON implements the [bson.Marshaler] interface for use as a standalone document.
 func (kvs KVs[K, V]) MarshalBSON() ([]byte, error) {
@@ -154,7 +155,7 @@ func (kvs KVs[K, V]) MarshalBSON() ([]byte, error) {
 	return bson.Marshal(m)
 }
 
-var _ bson.Marshaler = (*KVs[any, any])(nil)
+var _ bson.Unmarshaler = (*KVs[any, any])(nil)
 
 // UnmarshalBSON implements the [bson.Unmarshaler] interface for use as a standalone document.
 func (kvs *KVs[K, V]) UnmarshalBSON(data []byte) error {

--- a/kv.go
+++ b/kv.go
@@ -8,26 +8,26 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// KV represents a key-value pair with a comparable key and any value.
+// [KV] represents a key-value pair with a comparable key and any value.
 type KV[K comparable, V any] struct {
 	Key K
 	Val V
 }
 
-// KVFrom creates a KV pair from the given key and value.
+// [KVFrom] creates a [KV] pair from the given key and value.
 func KVFrom[K comparable, V any](key K, val V) KV[K, V] {
 	return KV[K, V]{Key: key, Val: val}
 }
 
-// KVs is a slice of KV pairs that provides utility methods for working with key-value collections.
+// [KVs] is a slice of [KV] pairs that provides utility methods for working with key-value collections.
 type KVs[K comparable, V any] []KV[K, V]
 
-// KVsFrom creates a KVs slice from the given KV pairs.
+// [KVsFrom] creates a [KVs] slice from the given [KV] pairs.
 func KVsFrom[K comparable, V any](kvs ...KV[K, V]) KVs[K, V] {
 	return kvs
 }
 
-// KVsFromMap creates a KVs slice from the given map of key-value pairs.
+// [KVsFromMap] creates a [KVs] slice from the given map of key-value pairs.
 func KVsFromMap[K comparable, V any](m map[K]V) KVs[K, V] {
 	kvs := make(KVs[K, V], 0, len(m))
 	for k, v := range m {
@@ -36,7 +36,7 @@ func KVsFromMap[K comparable, V any](m map[K]V) KVs[K, V] {
 	return kvs
 }
 
-// Keys returns a slice of all keys in the KVs collection.
+// Keys returns a slice of all keys in the [KVs] collection.
 func (kvs KVs[K, V]) Keys() []K {
 	keys := make([]K, len(kvs))
 	for i, kv := range kvs {
@@ -45,7 +45,7 @@ func (kvs KVs[K, V]) Keys() []K {
 	return keys
 }
 
-// Vals returns a slice of all values in the KVs collection.
+// Vals returns a slice of all values in the [KVs] collection.
 func (kvs KVs[K, V]) Vals() []V {
 	vals := make([]V, len(kvs))
 	for i, kv := range kvs {
@@ -54,7 +54,7 @@ func (kvs KVs[K, V]) Vals() []V {
 	return vals
 }
 
-// Map converts the KVs collection into a map of key-value pairs.
+// Map converts the [KVs] collection into a map of key-value pairs.
 func (kvs KVs[K, V]) Map() map[K]V {
 	m := make(map[K]V, len(kvs))
 	for _, kv := range kvs {
@@ -63,8 +63,10 @@ func (kvs KVs[K, V]) Map() map[K]V {
 	return m
 }
 
-// MarshalJSON implements the json.Marshaler interface.
-// KVs is serialized as a single JSON object: {"k1": v1, "k2": v2, ...}.
+var _ json.Marshaler = KVs[any, any]{}
+
+// MarshalJSON implements the [json.Marshaler] interface.
+// [KVs] is serialized as a single JSON object: {"k1": v1, "k2": v2, ...}.
 func (kvs KVs[K, V]) MarshalJSON() ([]byte, error) {
 	m := make(map[K]V, len(kvs))
 	for _, kv := range kvs {
@@ -73,7 +75,9 @@ func (kvs KVs[K, V]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface.
+var _ json.Unmarshaler = (*KVs[any, any])(nil)
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
 func (kvs *KVs[K, V]) UnmarshalJSON(data []byte) error {
 	var m map[K]V
 	if err := json.Unmarshal(data, &m); err != nil {
@@ -86,7 +90,9 @@ func (kvs *KVs[K, V]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Scan implements the sql.Scanner interface.
+var _ driver.Valuer = (*KVs[any, any])(nil)
+
+// Scan implements the [sql.Scanner] interface.
 // The column should be a type that can hold JSON data (JSONB, JSON, TEXT, etc).
 func (kvs *KVs[K, V]) Scan(src any) error {
 	if src == nil {
@@ -102,13 +108,17 @@ func (kvs *KVs[K, V]) Scan(src any) error {
 	return fmt.Errorf("typx.KVs.Scan: %T is not a string or []byte", src)
 }
 
-// Value implements the driver.Valuer interface.
+var _ driver.Valuer = (*KVs[any, any])(nil)
+
+// Value implements the [driver.Valuer] interface.
 func (kvs KVs[K, V]) Value() (driver.Value, error) {
 	return json.Marshal(kvs)
 }
 
-// MarshalBSONValue implements the bson.ValueMarshaler interface.
-// KVs is serialized as a single BSON document: {k1: v1, k2: v2, ...}.
+var _ bson.ValueMarshaler = (*KVs[any, any])(nil)
+
+// MarshalBSONValue implements the [bson.ValueMarshaler] interface.
+// [KVs] is serialized as a single BSON document: {k1: v1, k2: v2, ...}.
 func (kvs KVs[K, V]) MarshalBSONValue() (byte, []byte, error) {
 	m := make(map[K]V, len(kvs))
 	for _, kv := range kvs {
@@ -118,7 +128,9 @@ func (kvs KVs[K, V]) MarshalBSONValue() (byte, []byte, error) {
 	return byte(t), data, err
 }
 
-// UnmarshalBSONValue implements the bson.ValueUnmarshaler interface.
+var _ bson.ValueUnmarshaler = (*KVs[any, any])(nil)
+
+// UnmarshalBSONValue implements the [bson.ValueUnmarshaler] interface.
 func (kvs *KVs[K, V]) UnmarshalBSONValue(t byte, data []byte) error {
 	var m map[K]V
 	if err := bson.UnmarshalValue(bson.Type(t), data, &m); err != nil {
@@ -131,7 +143,9 @@ func (kvs *KVs[K, V]) UnmarshalBSONValue(t byte, data []byte) error {
 	return nil
 }
 
-// MarshalBSON implements the bson.Marshaler interface for use as a standalone document.
+var _ bson.ValueMarshaler = (*KVs[any, any])(nil)
+
+// MarshalBSON implements the [bson.Marshaler] interface for use as a standalone document.
 func (kvs KVs[K, V]) MarshalBSON() ([]byte, error) {
 	m := make(map[K]V, len(kvs))
 	for _, kv := range kvs {
@@ -140,7 +154,9 @@ func (kvs KVs[K, V]) MarshalBSON() ([]byte, error) {
 	return bson.Marshal(m)
 }
 
-// UnmarshalBSON implements the bson.Unmarshaler interface for use as a standalone document.
+var _ bson.Marshaler = (*KVs[any, any])(nil)
+
+// UnmarshalBSON implements the [bson.Unmarshaler] interface for use as a standalone document.
 func (kvs *KVs[K, V]) UnmarshalBSON(data []byte) error {
 	var m map[K]V
 	if err := bson.Unmarshal(data, &m); err != nil {

--- a/must.go
+++ b/must.go
@@ -1,6 +1,6 @@
 package typx
 
-// Must is a helper that panics if the error is non-nil, otherwise returning the value.
+// [Must] is a helper that panics if the error is non-nil, otherwise returning the value.
 func Must[T any](val T, err error) T {
 	if err != nil {
 		panic(err)
@@ -8,7 +8,7 @@ func Must[T any](val T, err error) T {
 	return val
 }
 
-// Must2 is a helper that panics if the error is non-nil, otherwise returning the two values.
+// [Must2] is a helper that panics if the error is non-nil, otherwise returning the two values.
 func Must2[T, U any](val T, val2 U, err error) (T, U) {
 	if err != nil {
 		panic(err)
@@ -16,7 +16,7 @@ func Must2[T, U any](val T, val2 U, err error) (T, U) {
 	return val, val2
 }
 
-// Must3 is a helper that panics if the error is non-nil, otherwise returning the three values.
+// [Must3] is a helper that panics if the error is non-nil, otherwise returning the three values.
 func Must3[T, U, V any](val T, val2 U, val3 V, err error) (T, U, V) {
 	if err != nil {
 		panic(err)

--- a/nil.go
+++ b/nil.go
@@ -10,18 +10,18 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// Nil is a type that can be used to represent a nil/nullable value.
+// [Nil] is a type that can be used to represent a nil/nullable value.
 // It implements most of the interfaces that are used to marshal and unmarshal values.
-// For optional values that are not present, use Opt[T] instead.
+// For optional values that are not present, use [Opt] instead.
 type Nil[T any] struct {
 	Val    T
 	NotNil bool
 }
 
-// NilFrom creates a Nil[T] from a non-nil value.
+// NilFrom creates a [Nil] from a non-nil value.
 func NilFrom[T any](value T) Nil[T] { return Nil[T]{Val: value, NotNil: true} }
 
-// NilFromPtr creates a Nil[T] from a pointer. If the pointer is nil, NotNil is false.
+// NilFromPtr creates a [Nil] from a pointer. If the pointer is nil, NotNil is false.
 func NilFromPtr[T any](value *T) Nil[T] {
 	if value == nil {
 		return Nil[T]{}
@@ -38,7 +38,9 @@ func (n Nil[T]) Ptr() *T {
 	return &n.Val
 }
 
-// Scan implements the sql.Scanner interface.
+var _ sql.Scanner = (*Nil[any])(nil)
+
+// Scan implements the [sql.Scanner] interface.
 func (n *Nil[T]) Scan(src any) error {
 	n.NotNil = false
 	if src == nil {
@@ -74,7 +76,9 @@ func (n *Nil[T]) Scan(src any) error {
 	return fmt.Errorf("typx.Nil.Scan: %T does not implement sql.Scanner and cannot be scanned from %T", n.Val, src)
 }
 
-// Value implements the driver.Valuer interface.
+var _ driver.Valuer = (*Nil[any])(nil)
+
+// Value implements the [driver.Valuer] interface.
 func (n Nil[T]) Value() (driver.Value, error) {
 	if !n.NotNil {
 		return nil, nil
@@ -85,7 +89,9 @@ func (n Nil[T]) Value() (driver.Value, error) {
 	return n.Val, nil
 }
 
-// MarshalBinary implements the encoding.BinaryMarshaler interface.
+var _ encoding.BinaryMarshaler = Nil[any]{}
+
+// MarshalBinary implements the [encoding.BinaryMarshaler] interface.
 func (n Nil[T]) MarshalBinary() ([]byte, error) {
 	if !n.NotNil {
 		return []byte(nil), nil
@@ -101,7 +107,9 @@ func (n Nil[T]) MarshalBinary() ([]byte, error) {
 	return nil, fmt.Errorf("typx.Nil.MarshalBinary: %T does not implement encoding.BinaryMarshaler and is not a string or []byte", n.Val)
 }
 
-// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+var _ encoding.BinaryUnmarshaler = (*Nil[any])(nil)
+
+// UnmarshalBinary implements the [encoding.BinaryUnmarshaler] interface.
 func (n *Nil[T]) UnmarshalBinary(data []byte) error {
 	n.NotNil = false
 	if data == nil {
@@ -131,7 +139,9 @@ func (n *Nil[T]) UnmarshalBinary(data []byte) error {
 	return fmt.Errorf("typx.Nil.UnmarshalBinary: %T does not implement encoding.BinaryUnmarshaler and is not a string or []byte", n.Val)
 }
 
-// MarshalText implements the encoding.TextMarshaler interface.
+var _ encoding.TextMarshaler = Nil[any]{}
+
+// MarshalText implements the [encoding.TextMarshaler] interface.
 func (n Nil[T]) MarshalText() ([]byte, error) {
 	if !n.NotNil {
 		return []byte("null"), nil
@@ -147,7 +157,9 @@ func (n Nil[T]) MarshalText() ([]byte, error) {
 	return nil, fmt.Errorf("typx.Nil.MarshalText: %T does not implement encoding.TextMarshaler and is not a string or []byte", n.Val)
 }
 
-// UnmarshalText implements the encoding.TextUnmarshaler interface.
+var _ encoding.TextUnmarshaler = (*Nil[any])(nil)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
 func (n *Nil[T]) UnmarshalText(data []byte) error {
 	n.NotNil = false
 	if data == nil {
@@ -177,7 +189,9 @@ func (n *Nil[T]) UnmarshalText(data []byte) error {
 	return fmt.Errorf("typx.Nil.UnmarshalText: %T does not implement encoding.TextUnmarshaler and is not a string or []byte", n.Val)
 }
 
-// MarshalJSON implements the json.Marshaler interface.
+var _ bson.ValueMarshaler = Nil[any]{}
+
+// MarshalJSON implements the [json.Marshaler] interface.
 func (n Nil[T]) MarshalJSON() ([]byte, error) {
 	if !n.NotNil {
 		return []byte("null"), nil
@@ -185,7 +199,9 @@ func (n Nil[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(n.Val)
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface.
+var _ json.Unmarshaler = (*Nil[any])(nil)
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
 func (n *Nil[T]) UnmarshalJSON(data []byte) error {
 	n.NotNil = false
 	var t *T
@@ -201,6 +217,8 @@ func (n *Nil[T]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+var _ bson.ValueMarshaler = (*Nil[any])(nil)
+
 // MarshalBSONValue implements the bson.ValueMarshaler interface.
 func (n Nil[T]) MarshalBSONValue() (byte, []byte, error) {
 	if !n.NotNil {
@@ -209,6 +227,8 @@ func (n Nil[T]) MarshalBSONValue() (byte, []byte, error) {
 	t, data, err := bson.MarshalValue(n.Val)
 	return byte(t), data, err
 }
+
+var _ bson.ValueUnmarshaler = (*Nil[any])(nil)
 
 // UnmarshalBSONValue implements the bson.ValueUnmarshaler interface.
 func (n *Nil[T]) UnmarshalBSONValue(t byte, data []byte) error {

--- a/nil.go
+++ b/nil.go
@@ -18,10 +18,10 @@ type Nil[T any] struct {
 	NotNil bool
 }
 
-// NilFrom creates a [Nil] from a non-nil value.
+// [NilFrom] creates a [Nil] from a non-nil value.
 func NilFrom[T any](value T) Nil[T] { return Nil[T]{Val: value, NotNil: true} }
 
-// NilFromPtr creates a [Nil] from a pointer. If the pointer is nil, NotNil is false.
+// [NilFromPtr] creates a [Nil] from a pointer. If the pointer is nil, NotNil is false.
 func NilFromPtr[T any](value *T) Nil[T] {
 	if value == nil {
 		return Nil[T]{}
@@ -29,7 +29,7 @@ func NilFromPtr[T any](value *T) Nil[T] {
 	return Nil[T]{Val: *value, NotNil: true}
 }
 
-// Ptr returns a pointer to the value if NotNil is true, otherwise nil.
+// [Ptr] returns a pointer to the value if NotNil is true, otherwise nil.
 // It uses a non-pointer receiver so that the modified pointer does not affect the original value.
 func (n Nil[T]) Ptr() *T {
 	if !n.NotNil {

--- a/nil.go
+++ b/nil.go
@@ -189,7 +189,7 @@ func (n *Nil[T]) UnmarshalText(data []byte) error {
 	return fmt.Errorf("typx.Nil.UnmarshalText: %T does not implement encoding.TextUnmarshaler and is not a string or []byte", n.Val)
 }
 
-var _ bson.ValueMarshaler = Nil[any]{}
+var _ json.Marshaler = Nil[any]{}
 
 // MarshalJSON implements the [json.Marshaler] interface.
 func (n Nil[T]) MarshalJSON() ([]byte, error) {

--- a/opt.go
+++ b/opt.go
@@ -7,25 +7,27 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// Opt is a type that can be used to represent an optional value (present vs. absent).
+// [Opt] is a type that can be used to represent an optional value (present vs. absent).
 // It should be used for fields that may be missing entirely in serialized form.
-// For nullable values (present but null), use Nil[T] instead.
-// Combining both is possible: Opt[Nil[T]] represents a field that can be absent, null, or a value.
+// For nullable values (present but null), use [Nil] instead.
+// Combining both is possible: [Opt][[Nil][T]] represents a field that can be absent, null, or a value.
 //
-// Use the `omitzero` JSON struct tag to omit absent fields:
+// Use the `omitzero` JSON struct tag to omit absent fields. Example:
 //
-//	Field Opt[int] `json:"field,omitzero"`
+//	type Struct struct {
+//		Field Opt[int] `json:"field,omitzero"`
+//	}
 type Opt[T any] struct {
 	Val T
 	Set bool
 }
 
-// OptFrom creates an Opt[T] that is set to the given value.
+// OptFrom creates an [Opt] that is set to the given value.
 func OptFrom[T any](value T) Opt[T] {
 	return Opt[T]{Val: value, Set: true}
 }
 
-// OptFromPtr creates an Opt[T] from a pointer. If the pointer is nil, the result is unset.
+// OptFromPtr creates an [Opt] from a pointer. If the pointer is nil, the result is unset.
 func OptFromPtr[T any](ptr *T) Opt[T] {
 	if ptr == nil {
 		return Opt[T]{Set: false}
@@ -37,6 +39,8 @@ func OptFromPtr[T any](ptr *T) Opt[T] {
 // This enables the `omitzero` struct tag in encoding/json (Go 1.24+).
 func (o Opt[T]) IsZero() bool { return !o.Set }
 
+var _ json.Marshaler = Opt[any]{}
+
 // MarshalJSON marshals the inner value transparently.
 // Returns an error if the value is not set, to prevent silent null serialization.
 // Use the `omitzero` struct tag to omit absent fields instead of marshaling them directly.
@@ -47,14 +51,18 @@ func (o Opt[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(o.Val)
 }
 
+var _ json.Unmarshaler = (*Opt[any])(nil)
+
 // UnmarshalJSON is called only when the field is present in the JSON input (even as null).
-// It always marks the Opt as set and delegates to the inner type.
+// It always marks the [Opt] as set and delegates to the inner type.
 func (o *Opt[T]) UnmarshalJSON(data []byte) error {
 	o.Set = true
 	return json.Unmarshal(data, &o.Val)
 }
 
-// MarshalBSONValue implements the bson.ValueMarshaler interface.
+var _ bson.ValueMarshaler = Opt[any]{}
+
+// MarshalBSONValue implements the [bson.ValueMarshaler] interface.
 // Returns an error if the value is not set, to prevent silent null serialization.
 // Use the `omitempty` struct tag to omit absent fields instead of marshaling them directly.
 func (o Opt[T]) MarshalBSONValue() (byte, []byte, error) {
@@ -65,7 +73,9 @@ func (o Opt[T]) MarshalBSONValue() (byte, []byte, error) {
 	return byte(t), data, err
 }
 
-// UnmarshalBSONValue implements the bson.ValueUnmarshaler interface.
+var _ bson.ValueUnmarshaler = (*Opt[any])(nil)
+
+// UnmarshalBSONValue implements the [bson.ValueUnmarshaler] interface.
 // It always marks the Opt as set and delegates to the inner type.
 func (o *Opt[T]) UnmarshalBSONValue(t byte, data []byte) error {
 	o.Set = true

--- a/opt.go
+++ b/opt.go
@@ -22,12 +22,12 @@ type Opt[T any] struct {
 	Set bool
 }
 
-// OptFrom creates an [Opt] that is set to the given value.
+// [OptFrom] creates an [Opt] that is set to the given value.
 func OptFrom[T any](value T) Opt[T] {
 	return Opt[T]{Val: value, Set: true}
 }
 
-// OptFromPtr creates an [Opt] from a pointer. If the pointer is nil, the result is unset.
+// [OptFromPtr] creates an [Opt] from a pointer. If the pointer is nil, the result is unset.
 func OptFromPtr[T any](ptr *T) Opt[T] {
 	if ptr == nil {
 		return Opt[T]{Set: false}

--- a/ordered.go
+++ b/ordered.go
@@ -1,25 +1,29 @@
 package typx
 
-// Ordered is a type constraint that matches any type that implements a total ordering via the Compare method.
-// Types implementing Ordered can use the OrderedRange and OrderedMultiRange types in this package.
-// Additionally, if an Ordered type implements PGBoundMarshaler and PGBoundUnmarshaler,
+type ordered struct{}
+
+func (o ordered) Compare(other ordered) int { return 0 }
+
+// [Ordered] is a type constraint that matches any type that implements a total ordering via the Compare method.
+// Types implementing [Ordered] can use the [OrderedRange] and [OrderedMultiRange] types in this package.
+// Additionally, if an [Ordered] type implements [PGBoundMarshaler] and [PGBoundUnmarshaler],
 // it can be used with PostgreSQL range types in a way that produces native range literals instead of JSON-encoded values.
 type Ordered[T any] interface {
 	Compare(T) int
 }
 
-// PGBoundMarshaler is implemented by values that can serialize themselves as a PostgreSQL
+// [PGBoundMarshaler] is implemented by values that can serialize themselves as a PostgreSQL
 // range bound literal (e.g. "2024-01-01 00:00:00+00" for tstzrange, "12345" for numrange).
-// OrderedRange.Value and OrderedMultiRange.Value use this to produce a native PG range
+// [OrderedRange].Value and [OrderedMultiRange].Value use this to produce a native PG range
 // literal; types that don't implement it are JSON-encoded instead.
 // In non-PostgreSQL but still SQL contexts, the same PostgreSQL range literal syntax is used but without relying on the database to parse it.
 type PGBoundMarshaler interface {
 	MarshalPGBound() ([]byte, error)
 }
 
-// PGBoundUnmarshaler is implemented by values that can deserialize themselves from a
+// [PGBoundUnmarshaler] is implemented by values that can deserialize themselves from a
 // PostgreSQL range bound literal.
-// OrderedRange.Scan and OrderedMultiRange.Scan use this to parse a native PG range
+// [OrderedRange].Scan and [OrderedMultiRange].Scan use this to parse a native PG range
 // literal; types that don't implement it are JSON-decoded instead.
 // In non-PostgreSQL but still SQL contexts, the same PostgreSQL range literal syntax is used but without relying on the database to parse it.
 type PGBoundUnmarshaler interface {

--- a/ptr.go
+++ b/ptr.go
@@ -1,6 +1,6 @@
 package typx
 
-// Ptr creates a pointer to the receiver copy of the given value.
+// [Ptr] creates a pointer to the receiver copy of the given value.
 // Useful for inline pointer creation such as function calls.
 //
 // Deprecated: Since Go 1.26, you can use the built-in new(value) instead.
@@ -8,7 +8,7 @@ func Ptr[T any](value T) *T {
 	return &value
 }
 
-// FromPtr safely dereferences the given pointer and returns it along with a boolean
+// [FromPtr] safely dereferences the given pointer and returns it along with a boolean
 // indicating whether the pointer was non-nil.
 func FromPtr[T any](ptr *T) (T, bool) {
 	if ptr == nil {
@@ -17,7 +17,7 @@ func FromPtr[T any](ptr *T) (T, bool) {
 	return *ptr, true
 }
 
-// FromPtrOrZero safely dereferences the given pointer and returns its value.
+// [FromPtrOrZero] safely dereferences the given pointer and returns its value.
 // If the pointer is nil, it returns the zero value of T.
 func FromPtrOrZero[T any](ptr *T) T {
 	if ptr == nil {

--- a/range.go
+++ b/range.go
@@ -2,13 +2,14 @@ package typx
 
 import (
 	"cmp"
+	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"slices"
 	"strings"
 )
 
-// Bound represents one end of a range with its value and whether it is exclusive.
+// [Bound] represents one end of a range with its value and whether it is exclusive.
 // The zero value is inclusive (Exclusive == false) and bounded.
 // When Unbounded is true the bound is ±∞; Val and Exclusive are ignored.
 type Bound[O cmp.Ordered] struct {
@@ -17,7 +18,7 @@ type Bound[O cmp.Ordered] struct {
 	Unbounded bool `json:"unbounded,omitempty" bson:"unbounded,omitempty"` // whether this is an infinite/unbounded bound (true) or a finite bound (false)
 }
 
-// Range supports any cmp.Ordered type for in-process use, JSON, and BSON storage.
+// [Range] supports any cmp.Ordered type for in-process use, JSON, and BSON storage.
 // The Scan and Value methods implement PostgreSQL range literals; note that string-based
 // types have no corresponding PostgreSQL range type and should not be used with SQL.
 type Range[O cmp.Ordered] struct {
@@ -25,6 +26,7 @@ type Range[O cmp.Ordered] struct {
 	Upper Bound[O] `json:"upper" bson:"upper"` // upper bound
 }
 
+// Contains returns true if the given value is contained within the range.
 func (r Range[O]) Contains(val O) bool {
 	var lowerOk bool
 	if r.Lower.Unbounded {
@@ -43,7 +45,9 @@ func (r Range[O]) Contains(val O) bool {
 	return lowerOk && upperOk
 }
 
-// Scan implements the sql.Scanner interface for Range.
+var _ sql.Scanner = (*Range[byte])(nil)
+
+// Scan implements the [sql.Scanner] interface for [Range].
 // It expects a PostgreSQL range literal such as [min,max] or (min,max).
 func (r *Range[O]) Scan(src any) error {
 	var str string
@@ -93,7 +97,9 @@ func (r *Range[O]) Scan(src any) error {
 	return nil
 }
 
-// Value implements the driver.Valuer interface for Range.
+var _ driver.Valuer = (*Range[byte])(nil)
+
+// Value implements the [driver.Valuer] interface for [Range].
 // It returns a PostgreSQL range literal respecting the bound types, e.g. [min,max) or (min,max].
 func (r Range[O]) Value() (driver.Value, error) {
 	var lo, hi, lowerStr, upperStr string
@@ -164,7 +170,7 @@ func mergeUpper[O cmp.Ordered](a, b Bound[O]) Bound[O] {
 	return a
 }
 
-// NewMultiRange takes a slice of ranges and returns a new multi range that is optimized by merging overlapping ranges.
+// [NewMultiRange] takes a slice of [Range]s and returns a new [MultiRange] that is optimized by merging overlapping ranges.
 func NewMultiRange[O cmp.Ordered](src []Range[O]) MultiRange[O] {
 	if len(src) == 0 {
 		return nil
@@ -208,6 +214,7 @@ func NewMultiRange[O cmp.Ordered](src []Range[O]) MultiRange[O] {
 	return mr
 }
 
+// Contains returns true if the given value is contained within any of the ranges in the multirange.
 func (mr MultiRange[O]) Contains(val O) bool {
 	for _, r := range mr {
 		if r.Contains(val) {
@@ -217,7 +224,9 @@ func (mr MultiRange[O]) Contains(val O) bool {
 	return false
 }
 
-// Scan implements the sql.Scanner interface for MultiRange.
+var _ sql.Scanner = (*MultiRange[byte])(nil)
+
+// Scan implements the [sql.Scanner] interface for [MultiRange].
 // It expects a PostgreSQL multirange literal such as {[1,5],[10,20]}.
 func (mr *MultiRange[O]) Scan(src any) error {
 	var str string
@@ -259,7 +268,9 @@ func (mr *MultiRange[O]) Scan(src any) error {
 	return nil
 }
 
-// Value implements the driver.Valuer interface for MultiRange.
+var _ driver.Valuer = (*MultiRange[byte])(nil)
+
+// Value implements the [driver.Valuer] interface for [MultiRange].
 // It returns a PostgreSQL multirange literal such as {[1,5],[10,20]}.
 func (mr MultiRange[O]) Value() (driver.Value, error) {
 	parts := make([]string, 0, len(mr))

--- a/range_ordered.go
+++ b/range_ordered.go
@@ -1,6 +1,7 @@
 package typx
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"strings"
 )
 
-// OrderedBound represents one end of an OrderedRange with its value and whether it is exclusive.
+// [OrderedBound] represents one end of an [OrderedRange] with its value and whether it is exclusive.
 // The zero value is inclusive (Exclusive == false) and bounded.
 // When Unbounded is true the bound is ±∞; Val and Exclusive are ignored.
 type OrderedBound[O Ordered[O]] struct {
@@ -17,15 +18,16 @@ type OrderedBound[O Ordered[O]] struct {
 	Unbounded bool `json:"unbounded,omitempty" bson:"unbounded,omitempty"` // whether this is an infinite/unbounded bound (true) or a finite bound (false)
 }
 
-// OrderedRange supports any Ordered type for in-process use, JSON, and BSON storage.
+// [OrderedRange] supports any [Ordered] type for in-process use, JSON, and BSON storage.
 // The Scan and Value methods implement PostgreSQL range literals; note that string-based
 // types have no corresponding PostgreSQL range type and should not be used with SQL.
-// In the case of a type implementing PGBoundUnmarshaler/Marshaler, those are used to parse/format the bounds of the range literal.
+// In the case of a type implementing [PGBoundUnmarshaler]/[PGBoundMarshaler], those are used to parse/format the bounds of the range literal.
 type OrderedRange[O Ordered[O]] struct {
 	Lower OrderedBound[O] `json:"lower" bson:"lower"` // lower bound
 	Upper OrderedBound[O] `json:"upper" bson:"upper"` // upper bound
 }
 
+// Contains returns true if the given value is contained within the range.
 func (r OrderedRange[O]) Contains(val O) bool {
 	var lowerOk bool
 	if r.Lower.Unbounded {
@@ -44,8 +46,10 @@ func (r OrderedRange[O]) Contains(val O) bool {
 	return lowerOk && upperOk
 }
 
-// Scan implements the sql.Scanner interface for OrderedRange.
-// If *O implements PGBoundUnmarshaler it parses a PostgreSQL range literal (e.g. [min,max]).
+var _ sql.Scanner = (*OrderedRange[ordered])(nil)
+
+// Scan implements the [sql.Scanner] interface for [OrderedRange].
+// If *O implements [PGBoundUnmarshaler] it parses a PostgreSQL range literal (e.g. [min,max]).
 // Otherwise it JSON-decodes a range object, suitable for text/jsonb columns.
 func (r *OrderedRange[O]) Scan(src any) error {
 	var str string
@@ -102,8 +106,10 @@ func (r *OrderedRange[O]) scanRangeLiteral(str string) error {
 	return nil
 }
 
-// Value implements the driver.Valuer interface for OrderedRange.
-// If O or *O implements PGBoundMarshaler it returns a PostgreSQL range literal (e.g. [min,max)).
+var _ driver.Valuer = (*OrderedRange[ordered])(nil)
+
+// Value implements the [driver.Valuer] interface for [OrderedRange].
+// If O or *O implements [PGBoundMarshaler] it returns a PostgreSQL range literal (e.g. [min,max)).
 // Otherwise it JSON-encodes the range for storage in a text/jsonb column.
 func (r OrderedRange[O]) Value() (driver.Value, error) {
 	var zero O
@@ -191,6 +197,7 @@ func (r OrderedRange[O]) valueRangeLiteralPtr() (driver.Value, error) {
 	return fmt.Sprintf("%s%s,%s%s", lo, lowerStr, upperStr, hi), nil
 }
 
+// [OrderedMultiRange] represents a slice of non-overlapping [OrderedRange]s of the same type, sorted by lower bound.
 type OrderedMultiRange[O Ordered[O]] []OrderedRange[O]
 
 func orderedRangeOverlaps[O Ordered[O]](current, r OrderedRange[O]) bool {
@@ -229,6 +236,7 @@ func mergeOrderedUpper[O Ordered[O]](a, b OrderedBound[O]) OrderedBound[O] {
 	return a
 }
 
+// [NewOrderedMultiRange] takes a slice of [OrderedRange]s and returns an [OrderedMultiRange] with overlapping or adjacent ranges merged.
 func NewOrderedMultiRange[O Ordered[O]](src []OrderedRange[O]) OrderedMultiRange[O] {
 	if len(src) == 0 {
 		return nil
@@ -272,6 +280,7 @@ func NewOrderedMultiRange[O Ordered[O]](src []OrderedRange[O]) OrderedMultiRange
 	return mr
 }
 
+// Contains returns true if the given value is contained within any of the ranges in the multi range.
 func (mr OrderedMultiRange[O]) Contains(val O) bool {
 	for _, r := range mr {
 		if r.Contains(val) {
@@ -281,8 +290,10 @@ func (mr OrderedMultiRange[O]) Contains(val O) bool {
 	return false
 }
 
-// Scan implements the sql.Scanner interface for OrderedMultiRange.
-// If *O implements PGBoundUnmarshaler it parses a PostgreSQL multirange literal (e.g. {[1,5],[10,20]}).
+var _ sql.Scanner = (*OrderedMultiRange[ordered])(nil)
+
+// Scan implements the [sql.Scanner] interface for [OrderedMultiRange].
+// If *O implements [PGBoundUnmarshaler] it parses a PostgreSQL multirange literal (e.g. {[1,5],[10,20]}).
 // Otherwise it JSON-decodes a JSON array of range objects, suitable for text/jsonb columns.
 func (mr *OrderedMultiRange[O]) Scan(src any) error {
 	var str string
@@ -332,8 +343,10 @@ func (mr *OrderedMultiRange[O]) scanMultiRangeLiteral(str string) error {
 	return nil
 }
 
-// Value implements the driver.Valuer interface for OrderedMultiRange.
-// If O or *O implements PGBoundMarshaler it returns a PostgreSQL multirange literal (e.g. {[1,5],[10,20]}).
+var _ driver.Valuer = (*OrderedMultiRange[ordered])(nil)
+
+// Value implements the [driver.Valuer] interface for [OrderedMultiRange].
+// If O or *O implements [PGBoundMarshaler] it returns a PostgreSQL multirange literal (e.g. {[1,5],[10,20]}).
 // Otherwise it JSON-encodes the multirange as a JSON array for storage in a text/jsonb column.
 func (mr OrderedMultiRange[O]) Value() (driver.Value, error) {
 	var zero O

--- a/str64.go
+++ b/str64.go
@@ -1,9 +1,13 @@
 package typx
 
-import "encoding/base64"
+import (
+	"encoding"
+	"encoding/base64"
+	"fmt"
+)
 
 /*
-Str64 is a named []byte type that encodes arbitrary byte slices as unpadded base64url strings
+[Str64] is a named []byte type that encodes arbitrary byte slices as unpadded base64url strings
 (alphabet: A-Z, a-z, 0-9, -, _) via [base64.RawURLEncoding]. Because it implements
 [encoding.TextMarshaler] / [encoding.TextUnmarshaler], it serialises automatically in
 JSON, and any other text-based transport or storage without extra conversion,
@@ -13,21 +17,15 @@ Typical use cases:
 
  1. Shorter UUID representation.
     A UUID is 16 bytes. As a standard hyphenated string it is 36 characters;
-    as Str64 it is 22 characters — a 39 % reduction — while still being URL-safe.
-
-    uid := uuid.New()
-    s := typx.Str64(uid[:])         // wrap bytes directly, no copy
-    fmt.Println(s)                  // e.g. "BpLnfgDsc2WD8F2qNkHydQ"
-    s2, _ := typx.FromString(s.String())
-    uid2, _ := uuid.FromBytes(s2)   // recover
+    as [Str64] it is 22 characters — a 39 % reduction — while still being URL-safe.
 
  2. Custom Variable-length identifiers.
-    When a UUID's 128 bits of entropy is more (or less) than needed, Str64 works
+    When a UUID's 128 bits of entropy is more (or less) than needed, [Str64] works
     for any byte length: 8 bytes (64-bit) encodes to 11 chars, 32 bytes to 43 chars.
 
  3. Compact string storage.
-    If a string's content is limited to the Str64 alphabet (A-Z, a-z, 0-9, -, _),
-    storing it as Str64 bytes saves 25 % of space (6 bits stored per byte instead of 8).
+    If a string's content is limited to the [Str64] alphabet (A-Z, a-z, 0-9, -, _),
+    storing it as [Str64] bytes saves 25 % of space (6 bits stored per byte instead of 8).
 
  4. Loggable binary values.
     Any []byte field (hashes, tokens, raw IDs) becomes a human-readable, URL- and
@@ -35,8 +33,8 @@ Typical use cases:
 */
 type Str64 []byte
 
-// FromString decodes a base64 RawURL string back to the original raw bytes.
-func FromString(s string) (Str64, error) {
+// [Str64From] decodes a base64 RawURL string back to the original raw bytes.
+func Str64From(s string) (Str64, error) {
 	b, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
 		return nil, err
@@ -44,21 +42,27 @@ func FromString(s string) (Str64, error) {
 	return Str64(b), nil
 }
 
+var _ fmt.Stringer = Str64{}
+
 // String encodes the raw bytes to their base64 RawURL text representation.
 func (s Str64) String() string {
 	return base64.RawURLEncoding.EncodeToString(s)
 }
 
-// MarshalText implements encoding.TextMarshaler.
+var _ encoding.TextMarshaler = Str64{}
+
+// MarshalText implements [encoding.TextMarshaler].
 func (s Str64) MarshalText() ([]byte, error) {
 	out := make([]byte, base64.RawURLEncoding.EncodedLen(len(s)))
 	base64.RawURLEncoding.Encode(out, s)
 	return out, nil
 }
 
-// UnmarshalText implements encoding.TextUnmarshaler.
+var _ encoding.TextUnmarshaler = (*Str64)(nil)
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
 func (s *Str64) UnmarshalText(text []byte) error {
-	val, err := FromString(string(text))
+	val, err := Str64From(string(text))
 	if err != nil {
 		return err
 	}

--- a/str64_test.go
+++ b/str64_test.go
@@ -20,7 +20,7 @@ func Test_Str64_RoundTrip(t *testing.T) {
 	require.Len(t, str, 22)
 
 	// FromString recovers exactly the original 16 bytes — no slicing required.
-	s2, err := typx.FromString(str)
+	s2, err := typx.Str64From(str)
 	require.NoError(t, err)
 	require.Equal(t, s, s2)
 
@@ -44,6 +44,6 @@ func Test_Str64_MarshalUnmarshalText(t *testing.T) {
 }
 
 func Test_Str64_UnsupportedCharacter(t *testing.T) {
-	_, err := typx.FromString("hello!")
+	_, err := typx.Str64From("hello!")
 	require.Error(t, err)
 }

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package typx
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"strings"
@@ -8,23 +9,30 @@ import (
 )
 
 /*
-DateTime is a [time.Time] wrapper for use as an [OrderedRange] / [OrderedMultiRange] with tsrange, tstzrange, tsmultirange, and tstzmultirange backing types.
+[DateTime] is a [time.Time] wrapper for use as an [OrderedRange] / [OrderedMultiRange] with tsrange, tstzrange, tsmultirange, and tstzmultirange backing types.
 All constructors and methods strip the monotonic clock reading so
-that two DateTime values representing the same instant compare and marshal identically.
+that two [DateTime] values representing the same instant compare and marshal identically.
 
-This type also supports operations with the Duration type, which supports dynamic Month and Day components.
+This type also supports operations with the [Duration] type, which supports dynamic Month and Day components.
 */
 type DateTime struct{ time.Time }
 
+var _ Ordered[DateTime] = DateTime{}
+
+// Compare implements the [Ordered] interface by comparing the time values with the monotonic clock stripped.
 func (t DateTime) Compare(other DateTime) int {
 	return t.Time.Compare(other.Time)
 }
+
+var _ PGBoundMarshaler = DateTime{}
 
 // MarshalPGBound implements [PGBoundMarshaler].
 // Produces a PostgreSQL timestamptz literal.
 func (t DateTime) MarshalPGBound() ([]byte, error) {
 	return []byte(t.Time.Round(0).Format(time.RFC3339Nano)), nil
 }
+
+var _ PGBoundUnmarshaler = (*DateTime)(nil)
 
 // UnmarshalPGBound implements [PGBoundUnmarshaler].
 // Accepts a PostgreSQL timestamptz literal, including the double-quoted form
@@ -50,17 +58,21 @@ func (t *DateTime) UnmarshalPGBound(text []byte) error {
 	return fmt.Errorf("typx.DateTime.UnmarshalPGBound: cannot parse %q", s)
 }
 
+var _ driver.Valuer = DateTime{}
+
 // Value implements [driver.Valuer].
 // Returns the time with the monotonic clock stripped.
 func (t DateTime) Value() (driver.Value, error) {
 	return t.Time.Round(0), nil
 }
 
+var _ sql.Scanner = (*DateTime)(nil)
+
 // Scan implements [sql.Scanner].
 // The driver is expected to deliver a [time.Time] value (which pgx and database/sql
 // do for DATE, TIMESTAMP, and TIMESTAMPTZ columns alike).
 // A nil value (SQL NULL) zeroes the receiver.
-// Use Nil[DateTime] for a type that can be nil instead of zero.
+// Use [Nil][[DateTime]] for a type that can be nil instead of zero.
 func (t *DateTime) Scan(value any) error {
 	switch v := value.(type) {
 	case nil:
@@ -79,14 +91,14 @@ func (t *DateTime) Scan(value any) error {
 	return nil
 }
 
-// AddDuration adds a Duration with dynamic Month and Day components to the DateTime, returning a new DateTime.
+// AddDuration adds a [Duration] with dynamic Month and Day components to the [DateTime], returning a new [DateTime].
 func (t DateTime) AddDuration(d Duration) DateTime {
 	newTime := t.Time.Add(d.Time)
 	newTime = newTime.AddDate(0, int(d.Month), int(d.Day))
 	return DateTime{newTime.Round(0)}
 }
 
-// SubDateTime returns the Duration d such that t.Equal(other.AddDuration(d)).
+// SubDateTime returns the [Duration] d such that t.Equal(other.AddDuration(d)).
 func (t DateTime) SubDateTime(other DateTime) Duration {
 	yearDiff := t.Year() - other.Year()
 	monthDiff := int(t.Month()) - int(other.Month())

--- a/url.go
+++ b/url.go
@@ -1,0 +1,99 @@
+package typx
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding"
+	"fmt"
+	"net/url"
+)
+
+/*
+[URL] is a [url.URL] wrapper that serialises as a plain URL string in all common transports.
+
+Because it implements [encoding.TextMarshaler] / [encoding.TextUnmarshaler], JSON (and any
+other text-based format) represents the value as a quoted URL string with no extra nesting.
+
+It also implements [driver.Valuer] and [sql.Scanner] so it can be stored directly in any
+SQL column that holds text (VARCHAR, TEXT, etc.), without manual .String() / url.Parse calls
+at the call site:
+
+	type Row struct {
+	    ID       int
+	    Callback typx.URL
+	}
+
+Use [Nil][[URL]] for a nullable SQL column.
+*/
+type URL struct{ url.URL }
+
+// [URLFrom] parses str and returns a URL or an error.
+func URLFrom(str string) (URL, error) {
+	u, err := url.Parse(str)
+	if err != nil {
+		return URL{}, fmt.Errorf("typx.URLFrom: %w", err)
+	}
+	return URL{*u}, nil
+}
+
+var _ fmt.Stringer = URL{}
+
+// String returns the URL in its canonical string form.
+func (u URL) String() string {
+	return u.URL.String()
+}
+
+var _ encoding.TextMarshaler = URL{}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (u URL) MarshalText() ([]byte, error) {
+	return []byte(u.URL.String()), nil
+}
+
+var _ encoding.TextUnmarshaler = (*URL)(nil)
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (u *URL) UnmarshalText(text []byte) error {
+	parsed, err := url.Parse(string(text))
+	if err != nil {
+		return fmt.Errorf("typx.URL.UnmarshalText: %w", err)
+	}
+	u.URL = *parsed
+	return nil
+}
+
+var _ driver.Valuer = URL{}
+
+// Value implements [driver.Valuer].
+// The URL is stored as a plain string in the database.
+func (u URL) Value() (driver.Value, error) {
+	return u.URL.String(), nil
+}
+
+var _ sql.Scanner = (*URL)(nil)
+
+// Scan implements [sql.Scanner].
+// Accepts string or []byte from the driver.
+// A nil src (SQL NULL) zeroes the receiver.
+// Use Nil[[URL]] for a type that can be nil instead of zero.
+func (u *URL) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		u.URL = url.URL{}
+	case string:
+		parsed, err := url.Parse(v)
+		if err != nil {
+			return fmt.Errorf("typx.URL.Scan: %w", err)
+		}
+		u.URL = *parsed
+	case []byte:
+		parsed, err := url.Parse(string(v))
+		if err != nil {
+			return fmt.Errorf("typx.URL.Scan: %w", err)
+		}
+		u.URL = *parsed
+	default:
+		return fmt.Errorf("typx.URL.Scan: unsupported type %T", src)
+	}
+	return nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,104 @@
+package typx_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	typx "github.com/pedramktb/go-typx"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_URL_RoundTrip(t *testing.T) {
+	raw := "https://example.com/path?query=1#fragment"
+	u, err := typx.URLFrom(raw)
+	require.NoError(t, err)
+	require.Equal(t, raw, u.String())
+}
+
+func Test_URL_MarshalUnmarshalText(t *testing.T) {
+	raw := "https://example.com/path?query=1#fragment"
+	u, err := typx.URLFrom(raw)
+	require.NoError(t, err)
+
+	b, err := u.MarshalText()
+	require.NoError(t, err)
+
+	var u2 typx.URL
+	err = u2.UnmarshalText(b)
+	require.NoError(t, err)
+	require.Equal(t, u.String(), u2.String())
+}
+
+func Test_URL_JSONMarshalUnmarshal(t *testing.T) {
+	raw := "https://example.com/path?query=1"
+	u, err := typx.URLFrom(raw)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(u)
+	require.NoError(t, err)
+	require.Equal(t, `"`+raw+`"`, string(b))
+
+	var u2 typx.URL
+	err = json.Unmarshal(b, &u2)
+	require.NoError(t, err)
+	require.Equal(t, u.String(), u2.String())
+}
+
+func Test_URL_Scan_String(t *testing.T) {
+	raw := "https://example.com/path"
+	var u typx.URL
+	err := u.Scan(raw)
+	require.NoError(t, err)
+	require.Equal(t, raw, u.String())
+}
+
+func Test_URL_Scan_Bytes(t *testing.T) {
+	raw := "https://example.com/path"
+	var u typx.URL
+	err := u.Scan([]byte(raw))
+	require.NoError(t, err)
+	require.Equal(t, raw, u.String())
+}
+
+func Test_URL_Scan_Nil(t *testing.T) {
+	var u typx.URL
+	err := u.Scan(nil)
+	require.NoError(t, err)
+	require.Equal(t, "", u.String())
+}
+
+func Test_URL_Scan_UnsupportedType(t *testing.T) {
+	var u typx.URL
+	err := u.Scan(42)
+	require.Error(t, err)
+}
+
+func Test_URL_Scan_InvalidURL(t *testing.T) {
+	var u typx.URL
+	err := u.Scan("://invalid%gg")
+	require.Error(t, err)
+}
+
+func Test_URL_Value(t *testing.T) {
+	raw := "https://example.com/path?query=1"
+	u, err := typx.URLFrom(raw)
+	require.NoError(t, err)
+
+	val, err := u.Value()
+	require.NoError(t, err)
+	require.Equal(t, raw, val)
+}
+
+func Test_URL_Value_RoundTrip_Via_Scan(t *testing.T) {
+	raw := "https://user:pass@example.com:8080/path?k=v#anchor"
+	u, err := typx.URLFrom(raw)
+	require.NoError(t, err)
+
+	val, err := u.Value()
+	require.NoError(t, err)
+
+	var u2 typx.URL
+	err = u2.Scan(val)
+	require.NoError(t, err)
+	require.Equal(t, u.String(), u2.String())
+}


### PR DESCRIPTION
…odoc

- Add URL type (url.go, url_test.go): url.URL wrapper with text/JSON/SQL marshal support and Nil[URL] for nullable columns
- Rename FromString -> Str64From in str64.go for naming consistency; update str64_test.go accordingly
- Add compile-time interface assertion guards (var _ iface = Type{}) for all implemented interfaces
- Update godoc comments across duration.go, dyn.go, kv.go, must.go, nil.go, opt.go, ordered.go, ptr.go, range.go, range_ordered.go, str64.go, time.go to use [Name] cross-reference syntax